### PR TITLE
Override DNA/RNA pipeline configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY --from=builder \
   /root/genomon-api/target/genomon-api-0.1.0-SNAPSHOT-standalone.jar \
   /usr/share/genomon-api/genomon-api.jar
 COPY docker/genomon-api /usr/local/bin/genomon-api
+COPY resources/genomon_api/ /etc/genomon-api/genomon_api/
 ENTRYPOINT ["genomon-api"]
 ENV PORT 80
 EXPOSE 80

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [org.eclipse.jetty/jetty-server "9.4.31.v20200723"]
                  [ring/ring-codec "1.1.2"
                   :exclusions [commons-codec]] ;; duct/module.web
-                 [commons-codec "1.14"] ;; ring/ring-codec
+                 [commons-codec "1.15"] ;; ring/ring-codec
                  [org.apache.commons/commons-compress "1.19"]
                  [mysql/mysql-connector-java "8.0.19"]
                  [com.layerware/hugsql "0.5.1"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.474"]
                  [com.cognitect.aws/endpoints "1.1.11.842"]
-                 [com.cognitect.aws/s3 "784.2.593.0"]
+                 [com.cognitect.aws/s3 "809.2.734.0"]
                  [clj-commons/clj-yaml "0.7.0"]
                  [camel-snake-kebab "0.4.1"]
                  [instaparse "1.4.10"]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                   :exclusions [integrant]]
                  [duct/module.logging "0.5.0"]
                  [duct/module.sql "0.6.0"]
-                 [duct/module.web "0.7.0"
+                 [duct/module.web "0.7.1"
                   :exclusions [metosin/muuntaja
                                ring/ring-codec
                                org.eclipse.jetty/jetty-server]]

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                  [ring/ring-codec "1.1.2"
                   :exclusions [commons-codec]] ;; duct/module.web
                  [commons-codec "1.15"] ;; ring/ring-codec
-                 [org.apache.commons/commons-compress "1.19"]
+                 [org.apache.commons/commons-compress "1.20"]
                  [mysql/mysql-connector-java "8.0.19"]
                  [com.layerware/hugsql "0.5.1"]
                  [metosin/muuntaja "0.6.6"] ;; duct/module.web

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                   :exclusions [commons-codec]] ;; duct/module.web
                  [commons-codec "1.15"] ;; ring/ring-codec
                  [org.apache.commons/commons-compress "1.20"]
-                 [mysql/mysql-connector-java "8.0.19"]
+                 [mysql/mysql-connector-java "8.0.21"]
                  [com.layerware/hugsql "0.5.1"]
                  [metosin/muuntaja "0.6.6"] ;; duct/module.web
                  [metosin/jsonista "0.2.5"] ;; duct/module.web

--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,10 @@
   {:dev  [:project/dev :profiles/dev]
    :repl {:prep-tasks   ^:replace ["javac" "compile"]
           :repl-options {:init-ns user}}
-   :uberjar {:aot :all}
+   :uberjar {:aot :all,
+             :uberjar-exclusions ["genomon_api/config.edn"
+                                  "genomon_api/dna_param.edn"
+                                  "genomon_api/rna_param.edn"]}
    :profiles/dev {}
    :project/dev  {:source-paths   ["dev/src"]
                   :resource-paths ["dev/resources" "test/resources"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.gnu.org/licenses/gpl-3.0.html"}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.7.559"]
+                 [org.clojure/core.async "1.3.610"]
                  [integrant "0.8.0"]
                  [duct/core "0.8.0"
                   :exclusions [integrant]]

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.474"]
-                 [com.cognitect.aws/endpoints "1.1.11.714"]
+                 [com.cognitect.aws/endpoints "1.1.11.842"]
                  [com.cognitect.aws/s3 "784.2.593.0"]
                  [clj-commons/clj-yaml "0.7.0"]
                  [camel-snake-kebab "0.4.1"]

--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
                  [clj-commons/clj-yaml "0.7.2"]
                  [camel-snake-kebab "0.4.1"]
                  [instaparse "1.4.10"]
-                 [org.flatland/ordered "1.5.7"]
+                 [org.flatland/ordered "1.5.9"]
                  [io.dropwizard.metrics/metrics-core "4.1.2"]
                  [io.dropwizard.metrics/metrics-healthchecks "4.1.2"]]
   :plugins [[duct/lein-duct "0.12.1"]

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [org.apache.commons/commons-compress "1.20"]
                  [mysql/mysql-connector-java "8.0.21"]
                  [com.layerware/hugsql "0.5.1"]
-                 [metosin/muuntaja "0.6.6"] ;; duct/module.web
+                 [metosin/muuntaja "0.6.7"] ;; duct/module.web
                  [metosin/jsonista "0.2.5"] ;; duct/module.web
                  [metosin/reitit "0.4.2"]
                  [metosin/ring-http-response "0.9.1"]

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [mysql/mysql-connector-java "8.0.21"]
                  [com.layerware/hugsql "0.5.1"]
                  [metosin/muuntaja "0.6.7"] ;; duct/module.web
-                 [metosin/jsonista "0.2.5"] ;; duct/module.web
+                 [metosin/jsonista "0.2.7"] ;; duct/module.web
                  [metosin/reitit "0.4.2"]
                  [metosin/ring-http-response "0.9.1"]
                  [com.github.docker-java/docker-java "3.2.5"]

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  [com.cognitect.aws/api "0.8.474"]
                  [com.cognitect.aws/endpoints "1.1.11.842"]
                  [com.cognitect.aws/s3 "809.2.734.0"]
-                 [clj-commons/clj-yaml "0.7.0"]
+                 [clj-commons/clj-yaml "0.7.2"]
                  [camel-snake-kebab "0.4.1"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.5.7"]

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                   :exclusions [metosin/muuntaja
                                ring/ring-codec
                                org.eclipse.jetty/jetty-server]]
-                 [org.eclipse.jetty/jetty-server "9.4.15.v20190215"]
+                 [org.eclipse.jetty/jetty-server "9.4.31.v20200723"]
                  [ring/ring-codec "1.1.2"
                   :exclusions [commons-codec]] ;; duct/module.web
                  [commons-codec "1.14"] ;; ring/ring-codec

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.5.9"]
                  [io.dropwizard.metrics/metrics-core "4.1.12.1"]
-                 [io.dropwizard.metrics/metrics-healthchecks "4.1.2"]]
+                 [io.dropwizard.metrics/metrics-healthchecks "4.1.12.1"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]
   :main ^:skip-aot genomon-api.main

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [com.layerware/hugsql "0.5.1"]
                  [metosin/muuntaja "0.6.7"] ;; duct/module.web
                  [metosin/jsonista "0.2.7"] ;; duct/module.web
-                 [metosin/reitit "0.4.2"]
+                 [metosin/reitit "0.5.5"]
                  [metosin/ring-http-response "0.9.1"]
                  [com.github.docker-java/docker-java "3.2.5"]
                  [javax.activation/activation "1.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [com.github.docker-java/docker-java "3.2.5"]
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
-                 [com.cognitect.aws/api "0.8.423"]
+                 [com.cognitect.aws/api "0.8.474"]
                  [com.cognitect.aws/endpoints "1.1.11.714"]
                  [com.cognitect.aws/s3 "784.2.593.0"]
                  [clj-commons/clj-yaml "0.7.0"]

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [metosin/jsonista "0.2.5"] ;; duct/module.web
                  [metosin/reitit "0.4.2"]
                  [metosin/ring-http-response "0.9.1"]
-                 [com.github.docker-java/docker-java "3.1.5"]
+                 [com.github.docker-java/docker-java "3.2.5"]
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.423"]

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
                  [camel-snake-kebab "0.4.1"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.5.9"]
-                 [io.dropwizard.metrics/metrics-core "4.1.2"]
+                 [io.dropwizard.metrics/metrics-core "4.1.12.1"]
                  [io.dropwizard.metrics/metrics-healthchecks "4.1.2"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]

--- a/resources/genomon_api/config.edn
+++ b/resources/genomon_api/config.edn
@@ -55,5 +55,5 @@
  :duct.module.web/api {},
  :duct.module/sql {},
 
- :genomon-api.handler/module {},
+ :genomon-api.handler/module {:allow-config-overrides? true},
  :genomon-api.db.sql/module {:migration-dir "migrations"}}

--- a/src/genomon_api/handler.clj
+++ b/src/genomon_api/handler.clj
@@ -106,4 +106,4 @@
   #(duct/merge-configs
     %
     (into {} (map (juxt identity (constantly {})) (keys handler-refs)))
-    {::app {}}))
+    {::app {}, [:duct/const ::options] options}))

--- a/src/genomon_api/handler/pipelines/dna.clj
+++ b/src/genomon_api/handler/pipelines/dna.clj
@@ -36,11 +36,17 @@
   {:summary "Create a new run",
    :parameters {:body {:tumor {:r1 string?, :r2 string?},
                        (ds/opt :normal) {:r1 string?, :r2 string?},
-                       (ds/opt :control-panel) [string?]}},
+                       (ds/opt :control-panel) [string?]
+                       (ds/opt :config) (s/map-of
+                                         keyword?
+                                         (s/map-of keyword?
+                                                   (s/nilable string?)))}},
    :response {201 {:body {:run-id uuid?}}},
-   :handler (fn [{{:keys [body]} :parameters, ::r/keys [router]}]
+   :handler (fn [{{:keys [body]
+                   {:keys [config] :or {config dna-config}} :body} :parameters,
+                  ::r/keys [router]}]
               (let [id (UUID/randomUUID)
-                    run (exec/run-dna-pipeline executor id dna-config body)]
+                    run (exec/run-dna-pipeline executor id config body)]
                 (try
                   (db/create-dna-run db run)
                   (rur/created

--- a/src/genomon_api/handler/pipelines/dna.clj
+++ b/src/genomon_api/handler/pipelines/dna.clj
@@ -47,7 +47,8 @@
                    {:keys [config] :or {config dna-config}} :body} :parameters,
                   ::r/keys [router]}]
               (let [id (UUID/randomUUID)
-                    run (exec/run-dna-pipeline executor id config body)]
+                    samples (dissoc body :config)
+                    run (exec/run-dna-pipeline executor id config samples)]
                 (try
                   (db/create-dna-run db run)
                   (rur/created

--- a/src/genomon_api/handler/pipelines/dna.clj
+++ b/src/genomon_api/handler/pipelines/dna.clj
@@ -48,6 +48,8 @@
                   ::r/keys [router]}]
               (let [id (UUID/randomUUID)
                     samples (dissoc body :config)
+                    config (assoc-in config [:general :instance-option]
+                                     (:instance-option (:general dna-config)))
                     run (exec/run-dna-pipeline executor id config samples)]
                 (try
                   (db/create-dna-run db run)

--- a/src/genomon_api/handler/pipelines/dna.clj
+++ b/src/genomon_api/handler/pipelines/dna.clj
@@ -32,15 +32,16 @@
               {:status 200,
                :body {:runs (db/list-dna-runs db query)}})})
 
-(defhandler ::create-new-run [_ {:keys [db executor dna-config logger]}]
+(defhandler ::create-new-run [_ {:keys [db executor dna-config logger options]}]
   {:summary "Create a new run",
-   :parameters {:body {:tumor {:r1 string?, :r2 string?},
-                       (ds/opt :normal) {:r1 string?, :r2 string?},
-                       (ds/opt :control-panel) [string?]
-                       (ds/opt :config) (s/map-of
-                                         keyword?
+   :parameters {:body (cond-> {:tumor {:r1 string?, :r2 string?},
+                               (ds/opt :normal) {:r1 string?, :r2 string?},
+                               (ds/opt :control-panel) [string?]}
+                        (:allow-config-overrides? options)
+                        (assoc (ds/opt :config)
+                               (s/map-of keyword?
                                          (s/map-of keyword?
-                                                   (s/nilable string?)))}},
+                                                   (s/nilable string?)))))},
    :response {201 {:body {:run-id uuid?}}},
    :handler (fn [{{:keys [body]
                    {:keys [config] :or {config dna-config}} :body} :parameters,

--- a/src/genomon_api/handler/pipelines/rna.clj
+++ b/src/genomon_api/handler/pipelines/rna.clj
@@ -47,6 +47,8 @@
                   ::r/keys [router]}]
               (let [id (UUID/randomUUID)
                     samples (dissoc body :config)
+                    config (assoc-in config [:general :instance-option]
+                                     (:instance-option (:general rna-config)))
                     run (exec/run-rna-pipeline executor id config samples)]
                 (try
                   (db/create-rna-run db run)

--- a/src/genomon_api/handler/pipelines/rna.clj
+++ b/src/genomon_api/handler/pipelines/rna.clj
@@ -32,14 +32,15 @@
               {:status 200,
                :body {:runs (db/list-rna-runs db query)}})})
 
-(defhandler ::create-new-run [_ {:keys [db executor rna-config logger]}]
+(defhandler ::create-new-run [_ {:keys [db executor rna-config logger options]}]
   {:summary "Create a new run",
-   :parameters {:body {:r1 string?, :r2 string?,
-                       (ds/opt :control-panel) [string?],
-                       (ds/opt :config) (s/map-of
-                                         keyword?
+   :parameters {:body (cond-> {:r1 string?, :r2 string?,
+                               (ds/opt :control-panel) [string?]}
+                        (:allow-config-overrides? options)
+                        (assoc (ds/opt :config)
+                               (s/map-of keyword?
                                          (s/map-of keyword?
-                                                   (s/nilable string?)))}},
+                                                   (s/nilable string?)))))},
    :response {201 {:body {:run-id uuid?}}},
    :handler (fn [{{:keys [body]
                    {:keys [config] :or {config rna-config}} :body} :parameters,

--- a/src/genomon_api/handler/pipelines/rna.clj
+++ b/src/genomon_api/handler/pipelines/rna.clj
@@ -34,11 +34,18 @@
 
 (defhandler ::create-new-run [_ {:keys [db executor rna-config logger]}]
   {:summary "Create a new run",
-   :parameters {:body {:r1 string?, :r2 string?, (ds/opt :control-panel) [string?]}},
+   :parameters {:body {:r1 string?, :r2 string?,
+                       (ds/opt :control-panel) [string?],
+                       (ds/opt :config) (s/map-of
+                                         keyword?
+                                         (s/map-of keyword?
+                                                   (s/nilable string?)))}},
    :response {201 {:body {:run-id uuid?}}},
-   :handler (fn [{{:keys [body]} :parameters, ::r/keys [router]}]
+   :handler (fn [{{:keys [body]
+                   {:keys [config] :or {config rna-config}} :body} :parameters,
+                  ::r/keys [router]}]
               (let [id (UUID/randomUUID)
-                    run (exec/run-rna-pipeline executor id rna-config body)]
+                    run (exec/run-rna-pipeline executor id config body)]
                 (try
                   (db/create-rna-run db run)
                   (rur/created

--- a/src/genomon_api/handler/pipelines/rna.clj
+++ b/src/genomon_api/handler/pipelines/rna.clj
@@ -46,7 +46,8 @@
                    {:keys [config] :or {config rna-config}} :body} :parameters,
                   ::r/keys [router]}]
               (let [id (UUID/randomUUID)
-                    run (exec/run-rna-pipeline executor id config body)]
+                    samples (dissoc body :config)
+                    run (exec/run-rna-pipeline executor id config samples)]
                 (try
                   (db/create-rna-run db run)
                   (rur/created

--- a/src/genomon_api/handler/util.clj
+++ b/src/genomon_api/handler/util.clj
@@ -7,7 +7,8 @@
               :storage `(ig/ref :genomon-api/storage)
               :logger `(ig/ref :duct/logger)
               :dna-config `(ig/ref :genomon-api.executor.genomon-pipeline-cloud.config/dna),
-              :rna-config `(ig/ref :genomon-api.executor.genomon-pipeline-cloud.config/rna)}
+              :rna-config `(ig/ref :genomon-api.executor.genomon-pipeline-cloud.config/rna)
+              :options `(ig/ref :genomon-api.handler/options)}
         m (->> params
                second
                :keys

--- a/test/src/genomon_api/handler_test.clj
+++ b/test/src/genomon_api/handler_test.clj
@@ -283,6 +283,21 @@
                         :svs nil},
               :config config}
              (dissoc run :created-at :updated-at)))))
+  (testing "Start a new DNA run with an overridden config"
+    (let [config {:bwa-alignment
+                  {:image "genomon/bwa_alignment:0.2.0"}}
+          {post-status :status
+           {:keys [run-id]}
+           :body} (request
+                   :post "/api/pipelines/dna/runs"
+                   (pr-str {:tumor {:r1 "tr1", :r2 "tr2"}, :config config}))
+          {get-status :status
+           {:keys [run]} :body} (request
+                                 (str "/api/pipelines/dna/runs/" run-id))]
+      (is (= 201 post-status))
+      (is (uuid? run-id))
+      (is (= 200 get-status))
+      (is (= config (:config run)))))
   (testing "RNA config exists"
     (let [{:keys [status body]} (request "/api/pipelines/rna/config")]
       (is (= 200 status) "response ok")
@@ -371,4 +386,19 @@
                         :intron-retentions nil,
                         :svs nil},
               :config config}
-             (dissoc run :created-at :updated-at))))))
+             (dissoc run :created-at :updated-at)))))
+  (testing "Start a new RNA run with an overridden config"
+    (let [config {:bwa-alignment
+                  {:image "genomon/bwa_alignment:0.2.0"}}
+          {post-status :status
+           {:keys [run-id]}
+           :body} (request
+                   :post "/api/pipelines/rna/runs"
+                   (pr-str {:r1 "r1", :r2 "r2", :config config}))
+          {get-status :status
+           {:keys [run]} :body} (request
+                                 (str "/api/pipelines/rna/runs/" run-id))]
+      (is (= 201 post-status))
+      (is (uuid? run-id))
+      (is (= 200 get-status))
+      (is (= config (:config run))))))

--- a/test/src/genomon_api/handler_test.clj
+++ b/test/src/genomon_api/handler_test.clj
@@ -297,7 +297,8 @@
       (is (= 201 post-status))
       (is (uuid? run-id))
       (is (= 200 get-status))
-      (is (= config (:config run)))))
+      (is (= config (dissoc (:config run) :general)))
+      (is (string? (not-empty (:instance-option (:general (:config run))))))))
   (testing "RNA config exists"
     (let [{:keys [status body]} (request "/api/pipelines/rna/config")]
       (is (= 200 status) "response ok")
@@ -401,4 +402,5 @@
       (is (= 201 post-status))
       (is (uuid? run-id))
       (is (= 200 get-status))
-      (is (= config (:config run))))))
+      (is (= config (dissoc (:config run) :general)))
+      (is (string? (not-empty (:instance-option (:general (:config run)))))))))


### PR DESCRIPTION
This PR adds an optional functionality for overriding DNA/RNA pipeline configs.

I added an option `:allow-override-config?` to the `:genomon-api/handler` module in the duct config.
This option controls whether handlers optionally accept `:config` body parameter in requests which override default configs.
In other words, configs are overridden iff `:allow-override-config?` is truthy and a request has `:config` body parameter.

This PR also includes dependency upgrades and extraction of config files from uberjar.