### PR TITLE
GitHub Actions integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: build
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
+        run: |
+          SHA_TAG=git-`echo ${{ github.sha }} | cut -c 1-7`
+          BRANCH_TAG=`echo ${{ github.ref }} | sed -e "s!refs/heads/!!g" | sed -e "s!/!-!g" | sed -e "s/^master$/latest/g"`
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH_TAG

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # genomon-api
 
+[![build](https://github.com/chrovis-genomon/genomon-api/workflows/build/badge.svg)](https://github.com/chrovis-genomon/genomon-api/actions)
+
 `genomon-api` is an API server for Genomon pipelines.
 `genomon-api` supports the following operations over HTTP:
 - running DNA/RNA pipelines


### PR DESCRIPTION
This PR adds a configuration of GitHub Actions to push Docker images to Amazon ECR.

When pushed to this repository, the GitHub Actions builds the Docker image and adds the `git-[first 7 characters of SHA1]` tag to genomon-api image. If pushed to the master branch, the `latest` tag will be added.