### PR TITLE
Enable to pull a docker image from a private registry

### DIFF
--- a/resources/genomon_api/config.edn
+++ b/resources/genomon_api/config.edn
@@ -29,6 +29,8 @@
   :genomon-api.executor.genomon-pipeline-cloud/executor
   {:image "genomon_pipeline_cloud",
    :tag "latest",
+   :auth-config {:username #duct/env ["DOCKER_REGISTRY_AUTH_USERNAME"],
+                 :password #duct/env ["DOCKER_REGISTRY_AUTH_PASSWORD"]},
    :env {"AWS_ACCESS_KEY_ID" #duct/env ["AWS_ACCESS_KEY_ID"],
          "AWS_SECRET_ACCESS_KEY" #duct/env ["AWS_SECRET_ACCESS_KEY"],
          "AWS_DEFAULT_REGION" #duct/env ["AWS_DEFAULT_REGION"]},

--- a/src/genomon_api/docker/core.clj
+++ b/src/genomon_api/docker/core.clj
@@ -21,7 +21,7 @@
             CreateContainerCmd
             StartContainerCmd]
            [com.github.dockerjava.api.model
-            Volume Bind AccessMode Frame StreamType
+            Volume Bind AccessMode Frame StreamType AuthConfig
             ExposedPort Ports Ports$Binding WaitResponse]
            [com.github.dockerjava.jaxrs JerseyDockerCmdExecFactory]
            [com.fasterxml.jackson.databind ObjectMapper]
@@ -93,6 +93,17 @@
              :port default-registry-port
              :tag default-tag})))
 
+(defn- ->auth-config [{:keys [auth email password registry-address
+                              username identity-token registry-token]}]
+  (cond-> (AuthConfig.)
+    auth (.withAuth auth)
+    email (.withEmail email)
+    password (.withPassword password)
+    registry-address (.withRegistryAddress registry-address)
+    username (.withUsername username)
+    identity-token (.withIdentityToken identity-token)
+    registry-token (.withRegistrytoken registry-token)))
+
 (defn pull-image
   ([^DockerClient client image]
    (if-let [{:keys [registry port namespace image tag]} (image->map image)]
@@ -105,7 +116,7 @@
      tag (.withTag tag)
      platform (.withPlatform platform)
      registry (.withRegistry registry)
-     auth-config (.withAuthConfig auth-config)
+     auth-config (.withAuthConfig (->auth-config auth-config))
      true (-> ^PullImageResultCallback (.exec (PullImageResultCallback.))
               (.awaitSuccess)))))
 

--- a/src/genomon_api/executor/genomon_pipeline_cloud.clj
+++ b/src/genomon_api/executor/genomon_pipeline_cloud.clj
@@ -215,9 +215,12 @@
           :opt-un [::tag]))
 
 (defmethod ig/init-key ::executor
-  [_ {:keys [docker logger ch image tag] :as opts}]
+  [_ {:keys [docker logger ch image tag auth-config] :as opts}]
   (log/info logger ::prep-image {:image image, :tag tag})
-  (if-let [img (d/prep-image docker image (cond-> {} tag (assoc :tag tag)))]
+  (if-let [img (d/prep-image docker image
+                             (cond-> {}
+                               tag (assoc :tag tag)
+                               auth-config (assoc :auth-config auth-config)))]
     (do
       (log/info logger ::use-image img)
       (listen-running-pipelines! opts)


### PR DESCRIPTION
This PR enables `genomon-api` to pull a docker image from a private registry like ECR.
Two config values `DOCKER_REGISTRY_AUTH_USERNAME` and `DOCKER_REGISTRY_AUTH_PSASWORD` are added.
For use with AWS ECR, use `"AWS"` as a username and `$(aws ecr get-login-password)` as a password.