### PR TITLE
Add env vars for a genomon docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ generated from HTTP requests and then mounted to the containers.
 
 ## Developing
 
+### Getting genomon_pipeline_cloud
+
+You need to get a docker image of [`genomon_pipeline_cloud`](https://github.com/chrovis/genomon_pipeline_cloud).
+If you don't have it, build one with the following command:
+
+```sh
+git clone https://github.com/chrovis/genomon_pipeline_cloud.git \
+  && cd genomon_pipeline_cloud \
+  && docker build . -t genomon_pipeline_cloud:latest
+```
+
+You can use other images by setting environment variables
+`GENOMON_DOCKER_IMAGE` and `GENOMON_DOCKER_IMAGE_TAG`.
+
 ### Setup
 
 When you first clone this repository, run:

--- a/resources/genomon_api/config.edn
+++ b/resources/genomon_api/config.edn
@@ -27,8 +27,8 @@
    :instance-option #ig/ref :genomon-api.executor.genomon-pipeline-cloud.config/instance-option},
 
   :genomon-api.executor.genomon-pipeline-cloud/executor
-  {:image "genomon_pipeline_cloud",
-   :tag "latest",
+  {:image #duct/env ["GENOMON_DOCKER_IMAGE" Str :or "genomon_pipeline_cloud"],
+   :tag #duct/env ["GENOMON_DOCKER_IMAGE_TAG" Str :or "latest"],
    :auth-config {:username #duct/env ["DOCKER_REGISTRY_AUTH_USERNAME"],
                  :password #duct/env ["DOCKER_REGISTRY_AUTH_PASSWORD"]},
    :env {"AWS_ACCESS_KEY_ID" #duct/env ["AWS_ACCESS_KEY_ID"],


### PR DESCRIPTION
This PR adds environment variables for specifying a docker image of `genomon_pipeline_cloud`.
The default behavior keeps the same as before.
Since it was unclear how to get the image, I also added a section for the instruction in README.