### PR TITLE
Allow using multiple subnets

### DIFF
--- a/dev/src/genomon_api_dev/db/sql.clj
+++ b/dev/src/genomon_api_dev/db/sql.clj
@@ -1,13 +1,18 @@
 (ns genomon-api-dev.db.sql
   (:require [clojure.java.jdbc :as jdbc])
-  (:import [org.h2.jdbc JdbcClob]))
+  (:import [org.h2.jdbc JdbcClob]
+           [java.sql Timestamp]))
 
 (extend-type JdbcClob
   jdbc/IResultSetReadColumn
   (result-set-read-column [clob _ _]
-    (let [])
     (with-open [r (.getCharacterStream clob)
                 w (java.io.StringWriter.)]
       (.transferTo r w)
       (.flush w)
       (.toString w))))
+
+(extend-type Timestamp
+  jdbc/IResultSetReadColumn
+  (result-set-read-column [ts _ _]
+    (.toLocalDateTime ts)))

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [mysql/mysql-connector-java "8.0.23"]
                  [com.layerware/hugsql "0.5.1"]
                  [metosin/muuntaja "0.6.7"] ;; duct/module.web
-                 [metosin/jsonista "0.2.7"] ;; duct/module.web
+                 [metosin/jsonista "0.3.1"] ;; duct/module.web
                  [metosin/reitit "0.5.5"]
                  [metosin/ring-http-response "0.9.1"]
                  [com.github.docker-java/docker-java "3.2.5"]

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [com.github.docker-java/docker-java "3.2.7"]
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
-                 [com.cognitect.aws/api "0.8.474"]
+                 [com.cognitect.aws/api "0.8.498"]
                  [com.cognitect.aws/endpoints "1.1.11.842"]
                  [com.cognitect.aws/s3 "809.2.734.0"]
                  [clj-commons/clj-yaml "0.7.2"]

--- a/project.clj
+++ b/project.clj
@@ -36,8 +36,8 @@
                  [camel-snake-kebab "0.4.2"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.5.9"]
-                 [io.dropwizard.metrics/metrics-core "4.1.12.1"]
-                 [io.dropwizard.metrics/metrics-healthchecks "4.1.12.1"]]
+                 [io.dropwizard.metrics/metrics-core "4.1.17"]
+                 [io.dropwizard.metrics/metrics-healthchecks "4.1.17"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]
   :main ^:skip-aot genomon-api.main

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [duct/core "0.8.0"
                   :exclusions [integrant]]
                  [duct/module.logging "0.5.0"]
-                 [duct/module.sql "0.6.0"]
+                 [duct/module.sql "0.6.1"]
                  [duct/module.web "0.7.1"
                   :exclusions [metosin/muuntaja
                                ring/ring-codec

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.498"]
                  [com.cognitect.aws/endpoints "1.1.11.934"]
-                 [com.cognitect.aws/s3 "809.2.734.0"]
+                 [com.cognitect.aws/s3 "810.2.817.0"]
                  [clj-commons/clj-yaml "0.7.2"]
                  [camel-snake-kebab "0.4.1"]
                  [instaparse "1.4.10"]

--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
                  [com.cognitect.aws/endpoints "1.1.11.934"]
                  [com.cognitect.aws/s3 "810.2.817.0"]
                  [clj-commons/clj-yaml "0.7.2"]
-                 [camel-snake-kebab "0.4.1"]
+                 [camel-snake-kebab "0.4.2"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.5.9"]
                  [io.dropwizard.metrics/metrics-core "4.1.12.1"]

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                   :exclusions [commons-codec]] ;; duct/module.web
                  [commons-codec "1.15"] ;; ring/ring-codec
                  [org.apache.commons/commons-compress "1.20"]
-                 [mysql/mysql-connector-java "8.0.21"]
+                 [mysql/mysql-connector-java "8.0.23"]
                  [com.layerware/hugsql "0.5.1"]
                  [metosin/muuntaja "0.6.7"] ;; duct/module.web
                  [metosin/jsonista "0.2.7"] ;; duct/module.web

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "GNU General Pulibc License, Version 3.0"
             :url "https://www.gnu.org/licenses/gpl-3.0.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.10.2"]
                  [org.clojure/core.async "1.3.610"]
                  [integrant "0.8.0"]
                  [duct/core "0.8.0"

--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,7 @@
    :profiles/dev {}
    :project/dev  {:source-paths   ["dev/src"]
                   :resource-paths ["dev/resources" "test/resources"]
-                  :dependencies   [[integrant/repl "0.3.1"]
+                  :dependencies   [[integrant/repl "0.3.2"]
                                    [hawk "0.2.11"]
                                    [eftest "0.5.9"]
                                    [kerodon "0.9.1"

--- a/project.clj
+++ b/project.clj
@@ -8,24 +8,20 @@
                  [org.clojure/core.async "1.3.610"]
                  [integrant "0.8.0"]
                  [duct/core "0.8.0"
-                  :exclusions [integrant]]
+                  :exclusions [medley]]
                  [duct/module.logging "0.5.0"]
                  [duct/module.sql "0.6.1"]
                  [duct/module.web "0.7.1"
-                  :exclusions [metosin/muuntaja
-                               ring/ring-codec
-                               org.eclipse.jetty/jetty-server]]
+                  :exclusions [ring/ring-core
+                               metosin/jsonista
+                               com.fasterxml.jackson.datatype/jackson-datatype-jsr310]]
                  [org.eclipse.jetty/jetty-server "9.4.36.v20210114"]
-                 [ring/ring-codec "1.1.2"
-                  :exclusions [commons-codec]] ;; duct/module.web
-                 [commons-codec "1.15"] ;; ring/ring-codec
                  [org.apache.commons/commons-compress "1.20"]
                  [mysql/mysql-connector-java "8.0.23"]
                  [com.layerware/hugsql "0.5.1"]
-                 [metosin/muuntaja "0.6.7"] ;; duct/module.web
-                 [metosin/jsonista "0.3.1"] ;; duct/module.web
                  [metosin/reitit "0.5.11"]
-                 [metosin/ring-http-response "0.9.1"]
+                 [metosin/ring-http-response "0.9.1"
+                  :exclusions [ring/ring-core]]
                  [com.github.docker-java/docker-java "3.2.7"]
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
@@ -61,9 +57,11 @@
                   :resource-paths ["dev/resources" "test/resources"]
                   :dependencies   [[integrant/repl "0.3.2"]
                                    [hawk "0.2.11"]
-                                   [eftest "0.5.9"]
+                                   [eftest "0.5.9"
+                                    :exclusions [mvxcvi/puget]]
                                    [kerodon "0.9.1"
-                                    :exclusions [ring/ring-codec]]
+                                    :exclusions [clj-time
+                                                 ring/ring-codec]]
                                    [com.h2database/h2 "1.4.200"]
                                    [com.gearswithingears/shrubbery "0.4.1"]]
                   :global-vars {*warn-on-reflection* true}}})

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [metosin/jsonista "0.3.1"] ;; duct/module.web
                  [metosin/reitit "0.5.11"]
                  [metosin/ring-http-response "0.9.1"]
-                 [com.github.docker-java/docker-java "3.2.5"]
+                 [com.github.docker-java/docker-java "3.2.7"]
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.474"]

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.498"]
-                 [com.cognitect.aws/endpoints "1.1.11.842"]
+                 [com.cognitect.aws/endpoints "1.1.11.934"]
                  [com.cognitect.aws/s3 "809.2.734.0"]
                  [clj-commons/clj-yaml "0.7.2"]
                  [camel-snake-kebab "0.4.1"]

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [com.layerware/hugsql "0.5.1"]
                  [metosin/muuntaja "0.6.7"] ;; duct/module.web
                  [metosin/jsonista "0.3.1"] ;; duct/module.web
-                 [metosin/reitit "0.5.5"]
+                 [metosin/reitit "0.5.11"]
                  [metosin/ring-http-response "0.9.1"]
                  [com.github.docker-java/docker-java "3.2.5"]
                  [javax.activation/activation "1.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                   :exclusions [metosin/muuntaja
                                ring/ring-codec
                                org.eclipse.jetty/jetty-server]]
-                 [org.eclipse.jetty/jetty-server "9.4.31.v20200723"]
+                 [org.eclipse.jetty/jetty-server "9.4.36.v20210114"]
                  [ring/ring-codec "1.1.2"
                   :exclusions [commons-codec]] ;; duct/module.web
                  [commons-codec "1.15"] ;; ring/ring-codec

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  [com.cognitect.aws/api "0.8.498"]
                  [com.cognitect.aws/endpoints "1.1.11.934"]
                  [com.cognitect.aws/s3 "810.2.817.0"]
-                 [clj-commons/clj-yaml "0.7.2"]
+                 [clj-commons/clj-yaml "0.7.106"]
                  [camel-snake-kebab "0.4.2"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.5.9"]

--- a/resources/genomon_api/config.edn
+++ b/resources/genomon_api/config.edn
@@ -51,7 +51,10 @@
                                :password #duct/env ["JDBC_PASSWORD"],
                                :use-ssl false,
                                :driver-class-name "com.mysql.cj.jdbc.Driver",
-                               :allow-public-key-retrieval true}},
+                               :allow-public-key-retrieval true,
+                               :preserve-instants true,
+                               :force-connection-time-zone-to-session false,
+                               :connection-time-zone "SERVER"}},
 
  :duct.module/logging {},
  :duct.module.web/api {},

--- a/resources/genomon_api/dna_param.edn
+++ b/resources/genomon_api/dna_param.edn
@@ -1,5 +1,5 @@
 {:bwa-alignment
- {:resource "--aws-ec2-instance-type t2.2xlarge --disk-size 64",
+ {:resource "--aws-ec2-instance-type t2.2xlarge --disk-size 80",
   :image "genomon/bwa_alignment:0.2.0",
   :bamtofastq-option
   "collate=1 combs=1 exclude=QCFAIL,SECONDARY,SUPPLEMENTARY tryoq=1",
@@ -12,7 +12,7 @@
  {:resource "--aws-ec2-instance-type t2.medium",
   :image "genomon/mutation_call:0.2.2",
   :reference "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37.fa",
-  :reference-idx "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37.fa.fai"
+  :reference-idx "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37.fa.fai",
   :fisher-single-option "--min_depth 8 --base_quality 15 --min_variant_read 2 --min_allele_freq 0.02 --post_10_q 0.02 -O vcf --print_header",
   :fisher-single-samtools "-q 20 -BQ0 --ff UNMAP,SECONDARY,QCFAIL,DUP"},
  :control-merge
@@ -20,10 +20,10 @@
   :image "genomon/mutation_call:0.2.2",
   :bcftools-option "-i B10:join,BM:join,B90:join -Oz -m none"},
  :mutation-call
- {:resource "--aws-ec2-instance-type m5.2xlarge",
+ {:resource "--aws-ec2-instance-type m5.2xlarge --disk-size 50",
   :image "genomon/mutation_call:0.2.2",
   :reference "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37.fa",
-  :reference-idx "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37.fa.fai"
+  :reference-idx "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37.fa.fai",
   :hotspot-database "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/hotspot/GRCh37_hotspot_database_v20170919.txt",
   :annotation-database "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/tabix",
   :fisher-interval-list "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37_8split.interval_list",
@@ -33,7 +33,7 @@
   :fisher-pair-samtools "-q 20 -BQ0 --ff UNMAP,SECONDARY,QCFAIL,DUP",
   :hotspot-call-option "-t 0.1 -c 0.1 -R 0.1 -m 8.0",
   :hotspot-call-samtools "-B -q 20 -Q2",
-  :realignment-option "--score_difference 5 --window_size 200 --max_depth 5000 --exclude_sam_flags 3332 -T 6",
+  :realignment-option "--score_difference 5 --window_size 200 --max_depth 5000 --exclude_sam_flags 3332 -T 8",
   :indel-option "--search_length 40 --neighbor 5 --min_depth 8 --min_mismatch 100000 --af_thres 1",
   :indel-samtools "-q 20 -BQ0 --ff UNMAP,SECONDARY,QCFAIL,DUP",
   :breakpoint-option "--max_depth 1000 --min_clip_size 20 --junc_num_thres 0 --mapq_thres 10 --exclude_sam_flags 3332",
@@ -42,21 +42,21 @@
   :active-hgvd-2016-flag "True",
   :active-exac-flag "True"},
  :sv-parse
- {:resource "--aws-ec2-instance-type t2.large",
+ {:resource "--aws-ec2-instance-type t2.large --disk-size 15",
   :image "genomon/genomon_sv:0.1.0",
   :genomon-sv-parse-option nil},
  :sv-merge
- {:resource "--aws-ec2-instance-type t2.large",
+ {:resource "--aws-ec2-instance-type t2.large --disk-size 15",
   :image "genomon/genomon_sv:0.1.0",
   :genomon-sv-merge-option nil},
  :sv-filt
- {:resource "--aws-ec2-instance-type t2.large",
+ {:resource "--aws-ec2-instance-type t2.large --disk-size 50",
   :image "genomon/genomon_sv:0.1.0",
   :reference "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/GRCh37/GRCh37.fa",
   :genomon-sv-filt-option "--grc --min_junc_num 2 --max_control_variant_read_pair 10 --min_overhang_size 30",
   :sv-utils-filt-option "--min_tumor_allele_freq 0.07 --max_control_variant_read_pair 1 --control_depth_thres 10 --inversion_size_thres 1000"},
  :qc
- {:resource "--aws-ec2-instance-type t2.medium",
+ {:resource "--aws-ec2-instance-type t2.medium --disk-size 15",
   :image "genomon/genomon_qc:0.2.2",
   :bait-file "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/bait/refGene.coding.exon.151207.bed",
   :gaptxt "s3://genomon-bucket-xcoo-archive-202001/_GRCh37/reference/hg19.fa/gap.txt",
@@ -70,7 +70,7 @@
   :samtools-params "-F 3332 -f 2"},
  :pmsignature
  {:enable "True",
-  :resource "--aws-ec2-instance-type t2.medium",
+  :resource "--aws-ec2-instance-type t2.medium --disk-size 5",
   :image "genomon/pmsignature:0.1.0",
   :signum-min "2",
   :signum-max "6",
@@ -82,7 +82,7 @@
   "TxDb.Hsapiens.UCSC.hg19.knownGene::TxDb.Hsapiens.UCSC.hg19.knownGene"},
  :signature
  {:enable "True",
-  :resource "--aws-ec2-instance-type t2.medium",
+  :resource "--aws-ec2-instance-type t2.medium --disk-size 5",
   :signum-min "2",
   :signum-max "6",
   :trdirflag "F",
@@ -92,7 +92,7 @@
   :txdb-transcript "TxDb.Hsapiens.UCSC.hg19.knownGene::TxDb.Hsapiens.UCSC.hg19.knownGene"},
  :paplot
  {:enable "True",
-  :resource "--aws-ec2-instance-type t2.medium",
+  :resource "--aws-ec2-instance-type t2.medium --disk-size 5",
   :image "genomon/paplot:0.1.0",
   :title "Genomon",
   :remarks "Data used in this report were generated using below software.",

--- a/src/genomon_api/db/sql.clj
+++ b/src/genomon_api/db/sql.clj
@@ -15,8 +15,7 @@
   (:import [java.nio ByteBuffer]
            [java.util UUID]
            [java.sql Timestamp]
-           [java.time Instant]
-           [java.net URL]))
+           [java.time Instant LocalDateTime ZoneId]))
 
 (defn- uuid->bin ^bytes [^UUID uuid]
   (let [bb (ByteBuffer/allocate 16)
@@ -32,8 +31,8 @@
         lsb (.get lb)]
     (UUID. msb lsb)))
 
-(defn- ts->inst ^Instant [^Timestamp ts]
-  (.toInstant ts))
+(defn- ts->inst ^Instant [^LocalDateTime ldt]
+  (.toInstant (.atZone ldt (ZoneId/systemDefault))))
 
 (defn- inst->ts ^Timestamp [^Instant i]
   (Timestamp/from i))

--- a/src/genomon_api/executor/genomon_pipeline_cloud.clj
+++ b/src/genomon_api/executor/genomon_pipeline_cloud.clj
@@ -201,7 +201,8 @@
 
 (s/def ::image string?)
 (s/def ::tag string?)
-(s/def ::aws-subnet-id (s/and string? #(re-matches #"subnet-[0-9a-f]+" %)))
+(s/def ::aws-subnet-id
+  (s/and string? #(re-matches #"(subnet-[0-9a-f]+)(,subnet-[0-9a-f]+)*" %)))
 (s/def ::aws-security-group-id (s/and string? #(re-matches #"sg-[0-9a-f]+" %)))
 (s/def ::aws-key-name (s/and string? not-empty))
 (s/def ::aws-ecs-instance-role-name (s/and string? not-empty))


### PR DESCRIPTION
This PR adds a feature to use multiple subnets with [`ecsub`](https://github.com/aokad/ecsub/blob/1a872309e5f33b8dcf4cfe53238a5634c219e8ea/scripts/ecsub/submit.py#L640).
The value for `:aws-subnet-id` now accepts comma-separated multiple subnet IDs.
We've been using this version for 4 months and it's working fine.