### PR TITLE
Fix docker inspection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Xcoo, Inc. <developer@xcoo.jp>"
 LABEL GIT_COMMIT=${GIT_COMMIT}
 ENV GIT_COMMIT=${GIT_COMMIT}
 COPY --from=builder \
-  /root/genomon-api/target/genomon-api-0.1.2-SNAPSHOT-standalone.jar \
+  /root/genomon-api/target/genomon-api-0.1.2-standalone.jar \
   /usr/share/genomon-api/genomon-api.jar
 COPY docker/genomon-api /usr/local/bin/genomon-api
 COPY resources/genomon_api/ /etc/genomon-api/genomon_api/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Xcoo, Inc. <developer@xcoo.jp>"
 LABEL GIT_COMMIT=${GIT_COMMIT}
 ENV GIT_COMMIT=${GIT_COMMIT}
 COPY --from=builder \
-  /root/genomon-api/target/genomon-api-0.1.2-standalone.jar \
+  /root/genomon-api/target/genomon-api-0.1.3-SNAPSHOT-standalone.jar \
   /usr/share/genomon-api/genomon-api.jar
 COPY docker/genomon-api /usr/local/bin/genomon-api
 COPY resources/genomon_api/ /etc/genomon-api/genomon_api/

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [com.github.docker-java/docker-java "3.2.12"]
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
-                 [com.cognitect.aws/api "0.8.524"]
+                 [com.cognitect.aws/api "0.8.539"]
                  [com.cognitect.aws/endpoints "1.1.12.88"]
                  [com.cognitect.aws/s3 "814.2.991.0"]
                  [clj-commons/clj-yaml "0.7.107"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject genomon-api "0.1.2"
+(defproject genomon-api "0.1.3-SNAPSHOT"
   :description "An API server of genomon_pipeline_cloud"
   :url "https://github.com/chrovis/genomon-api"
   :license {:name "GNU General Pulibc License, Version 3.0"

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.539"]
-                 [com.cognitect.aws/endpoints "1.1.12.88"]
+                 [com.cognitect.aws/endpoints "1.1.12.129"]
                  [com.cognitect.aws/s3 "814.2.991.0"]
                  [clj-commons/clj-yaml "0.7.107"]
                  [camel-snake-kebab "0.4.2"]

--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.15.10"]
                  [io.dropwizard.metrics/metrics-core "4.2.6"]
-                 [io.dropwizard.metrics/metrics-healthchecks "4.2.4"]]
+                 [io.dropwizard.metrics/metrics-healthchecks "4.2.6"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]
   :main ^:skip-aot genomon-api.main

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject genomon-api "0.1.2-SNAPSHOT"
+(defproject genomon-api "0.1.2"
   :description "An API server of genomon_pipeline_cloud"
   :url "https://github.com/chrovis/genomon-api"
   :license {:name "GNU General Pulibc License, Version 3.0"

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.gnu.org/licenses/gpl-3.0.html"}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.clojure/core.async "1.3.622"]
+                 [org.clojure/core.async "1.5.648"]
                  [integrant "0.8.0"]
                  [duct/core "0.8.0"
                   :exclusions [medley]]

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                   :exclusions [ring/ring-core
                                metosin/jsonista
                                com.fasterxml.jackson.datatype/jackson-datatype-jsr310]]
-                 [org.eclipse.jetty/jetty-server "11.0.7"]
+                 [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]
                  [org.apache.commons/commons-compress "1.21"]
                  [mysql/mysql-connector-java "8.0.27"]
                  [com.layerware/hugsql "0.5.1"]

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  [camel-snake-kebab "0.4.2"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.15.10"]
-                 [io.dropwizard.metrics/metrics-core "4.2.4"]
+                 [io.dropwizard.metrics/metrics-core "4.2.6"]
                  [io.dropwizard.metrics/metrics-healthchecks "4.2.4"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]

--- a/project.clj
+++ b/project.clj
@@ -62,6 +62,6 @@
                                    [kerodon "0.9.1"
                                     :exclusions [clj-time
                                                  ring/ring-codec]]
-                                   [com.h2database/h2 "1.4.200"]
+                                   [com.h2database/h2 "2.0.202"]
                                    [com.gearswithingears/shrubbery "0.4.1"]]
                   :global-vars {*warn-on-reflection* true}}})

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,10 @@
                  [duct/module.sql "0.6.1"]
                  [duct/module.web "0.7.3"
                   :exclusions [ring/ring-core
+                               ring/ring-codec
                                metosin/jsonista
+                               crypto-random
+                               commons-codec
                                com.fasterxml.jackson.datatype/jackson-datatype-jsr310]]
                  [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]
                  [org.apache.commons/commons-compress "1.21"]
@@ -22,7 +25,9 @@
                  [metosin/reitit "0.5.15"]
                  [metosin/ring-http-response "0.9.3"
                   :exclusions [ring/ring-core]]
-                 [com.github.docker-java/docker-java "3.2.12"]
+                 [com.github.docker-java/docker-java "3.2.12"
+                  :exclusions [commons-io
+                               commons-codec]]
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.539"]


### PR DESCRIPTION
In some cases, the application would fails to launch while inspecting docker containers.
This bug is introduced by #18 trying to `dissoc` non-persistent maps generated by the jackson object mapper (though they're printed just like persistent ones).
d4b362b fixes the problem by converting mapped objects into clojure's persistent structures recursively by `clojure.walk`.
https://github.com/chrovis-genomon/genomon-api/blob/d4b362bc83a7ce3e749eb78a9b1bb0be9db10560/src/genomon_api/docker/core.clj#L39-L51

This PR also contains...
- trivial refactoring (925c71b)
- dependency updates (d4b362b...a83f7dc)
- releasing version `0.1.2` (2f4e12c)