### PR TITLE
Fix regression caused by keywordized label names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Xcoo, Inc. <developer@xcoo.jp>"
 LABEL GIT_COMMIT=${GIT_COMMIT}
 ENV GIT_COMMIT=${GIT_COMMIT}
 COPY --from=builder \
-  /root/genomon-api/target/genomon-api-0.1.3-standalone.jar \
+  /root/genomon-api/target/genomon-api-0.1.4-SNAPSHOT-standalone.jar \
   /usr/share/genomon-api/genomon-api.jar
 COPY docker/genomon-api /usr/local/bin/genomon-api
 COPY resources/genomon_api/ /etc/genomon-api/genomon_api/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Xcoo, Inc. <developer@xcoo.jp>"
 LABEL GIT_COMMIT=${GIT_COMMIT}
 ENV GIT_COMMIT=${GIT_COMMIT}
 COPY --from=builder \
-  /root/genomon-api/target/genomon-api-0.1.3-SNAPSHOT-standalone.jar \
+  /root/genomon-api/target/genomon-api-0.1.3-standalone.jar \
   /usr/share/genomon-api/genomon-api.jar
 COPY docker/genomon-api /usr/local/bin/genomon-api
 COPY resources/genomon_api/ /etc/genomon-api/genomon_api/

--- a/project.clj
+++ b/project.clj
@@ -67,6 +67,6 @@
                                    [kerodon "0.9.1"
                                     :exclusions [clj-time
                                                  ring/ring-codec]]
-                                   [com.h2database/h2 "2.0.202"]
+                                   [com.h2database/h2 "2.1.210"]
                                    [com.gearswithingears/shrubbery "0.4.1"]]
                   :global-vars {*warn-on-reflection* true}}})

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.539"]
                  [com.cognitect.aws/endpoints "1.1.12.136"]
-                 [com.cognitect.aws/s3 "814.2.991.0"]
+                 [com.cognitect.aws/s3 "814.2.1053.0"]
                  [clj-commons/clj-yaml "0.7.107"]
                  [camel-snake-kebab "0.4.2"]
                  [instaparse "1.4.10"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.539"]
-                 [com.cognitect.aws/endpoints "1.1.12.129"]
+                 [com.cognitect.aws/endpoints "1.1.12.136"]
                  [com.cognitect.aws/s3 "814.2.991.0"]
                  [clj-commons/clj-yaml "0.7.107"]
                  [camel-snake-kebab "0.4.2"]

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [camel-snake-kebab "0.4.2"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.15.10"]
-                 [io.dropwizard.metrics/metrics-core "4.2.6"]
+                 [io.dropwizard.metrics/metrics-core "4.2.7"]
                  [io.dropwizard.metrics/metrics-healthchecks "4.2.6"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject genomon-api "0.1.3-SNAPSHOT"
+(defproject genomon-api "0.1.3"
   :description "An API server of genomon_pipeline_cloud"
   :url "https://github.com/chrovis/genomon-api"
   :license {:name "GNU General Pulibc License, Version 3.0"

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.15.10"]
                  [io.dropwizard.metrics/metrics-core "4.2.7"]
-                 [io.dropwizard.metrics/metrics-healthchecks "4.2.6"]]
+                 [io.dropwizard.metrics/metrics-healthchecks "4.2.7"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]
   :main ^:skip-aot genomon-api.main

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                                com.fasterxml.jackson.datatype/jackson-datatype-jsr310]]
                  [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]
                  [org.apache.commons/commons-compress "1.21"]
-                 [mysql/mysql-connector-java "8.0.27"]
+                 [mysql/mysql-connector-java "8.0.28"]
                  [com.layerware/hugsql "0.5.1"]
                  [metosin/reitit "0.5.15"]
                  [metosin/ring-http-response "0.9.3"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject genomon-api "0.1.3"
+(defproject genomon-api "0.1.4-SNAPSHOT"
   :description "An API server of genomon_pipeline_cloud"
   :url "https://github.com/chrovis/genomon-api"
   :license {:name "GNU General Pulibc License, Version 3.0"

--- a/src/genomon_api/db/worker.clj
+++ b/src/genomon_api/db/worker.clj
@@ -10,7 +10,7 @@
 (defmethod ig/init-key ::ch [_ {:keys [buf-or-n logger]}]
   (async/chan buf-or-n
               identity
-              (fn [e] (log/error ::unhandled {:error e}))))
+              (fn [e] (log/error logger ::unhandled {:error e}))))
 
 (defmethod ig/halt-key! ::ch [_ ch]
   (async/close! ch))

--- a/src/genomon_api/executor/genomon_pipeline_cloud.clj
+++ b/src/genomon_api/executor/genomon_pipeline_cloud.clj
@@ -140,7 +140,7 @@
            :as c} (d/list-containers
                    docker
                    {:show-all? true, :label-filter {"requester" "genomon-api"}})
-          :let [run (edn/read-string (get labels "run")) ;; Get info from a label
+          :let [run (edn/read-string (:run labels)) ;; Get info from a label
                 local-ch (async/chan
                           100
                           (keep (partial pipe-events (atom {}) logger run))
@@ -177,7 +177,7 @@
   (let [{:keys [id state labels] :as c} (->> {:name-filter [(str run-id)]}
                                              (d/list-containers docker)
                                              first)]
-    (when-not (= (get labels "pipeline-type") (name pipeline-type))
+    (when-not (= (:pipeline-type labels) (name pipeline-type))
       (throw (ex-info "Invalid pipeline type" {:pipeline-type pipeline-type,
                                                :run-id run-id,
                                                :container c})))

--- a/src/genomon_api/executor/genomon_pipeline_cloud.clj
+++ b/src/genomon_api/executor/genomon_pipeline_cloud.clj
@@ -143,7 +143,7 @@
           :let [run (edn/read-string (:run labels)) ;; Get info from a label
                 local-ch (async/chan
                           100
-                          (keep (partial pipe-events (atom {}) logger run))
+                          (keep (partial pipe-events (atom {}) m run))
                           (partial handle-error m run))
                 _ (async/pipe local-ch ch false)
                 info {:container-id id, :run run,


### PR DESCRIPTION
This PR fixes #21.

## Repro

To reproduce the error in question, follow the steps below:

1. Start a Docker container that will immediately terminate abnormally, e.g.:
```sh
docker run -l 'requester=genomon-api' -l 'run={:pipeline-type :dna}' --entrypoint=false chrovis-genomon/genomon_pipeline_cloud
```

2. Launch the Integrant component `:genomon-api.executor.genomon-pipeline-cloud/executor`:
```clojure
(require '[duct.core :as duct]
         '[integrant.core :as ig]
         '[genomon-api.executor.genomon-pipeline-cloud :as gpc])

(duct/load-hierarchy)

(-> (duct/resource "genomon_api/config.edn")
    (duct/read-config)
    (duct/prep-config [:duct.profile/dev])
    (ig/init [::gpc/executor]))
```

Then, you will see the expected error emitted to the log destination.

## Cause

This issue seems to be caused by #20, which was merged recently.

It recursively converts the Docker API response object into a Clojure data structure. As a result, the value of `labels` (labels attached to a Docker container), which used to be a map from the **label name string** to the label value, is now a map from the **label name keyword** to the label value. And hence, a portion of code that expects label names to be strings fails to handle label values correctly, which in turn causes the execution resumption code not to work properly.

## Solution

As a solution, this PR changes the code where label names are assumed to be strings to handle them as keywords (1eb8e6e).

The PR also includes minor fixes for error logging (e5b1e6a, ff5822b).