### PR TITLE
Disable QC tasks by default

### DIFF
--- a/src/genomon_api/util/csv.clj
+++ b/src/genomon_api/util/csv.clj
@@ -15,33 +15,40 @@
       `[[:bam-tofastq ~(mapv vector names control-panel)]
         [:controlpanel [["control_panel" ~@names]]]])))
 
-(defn gen-dna-input [{{normal-r1 :r1 normal-r2 :r2} :normal
-                      {tumor-r1 :r1 tumor-r2 :r2} :tumor
-                      :keys [control-panel]}]
-  (let [tumor-only? (not (and normal-r1 normal-r2))]
-    (-> `[[:fastq
-           ~(cond-> [["tumor" tumor-r1 tumor-r2]]
-              (not tumor-only?)
-              (conj ["normal" normal-r1 normal-r2]))]
-          ~@(gen-controlpanel-config control-panel)
-          [:mutation-call
-           [["tumor" ~(if tumor-only? "None" "normal") "None"]]]
-          [:sv-detection
-           [~(conj ["tumor"]
-                   (if tumor-only? "None" "normal")
-                   (if (seq control-panel) "control_panel" "None"))]]
-          [:qc
-           [["tumor"] ~@(when-not tumor-only? [["normal"]])]]]
-        (gen-input-file))))
+(defn gen-dna-input
+  ([samples] (gen-dna-input samples {}))
+  ([{{normal-r1 :r1 normal-r2 :r2} :normal
+     {tumor-r1 :r1 tumor-r2 :r2} :tumor
+     :keys [control-panel]}
+    {:keys [include-qc?]}]
+   (let [tumor-only? (not (and normal-r1 normal-r2))]
+     (-> `[[:fastq
+            ~(cond-> [["tumor" tumor-r1 tumor-r2]]
+               (not tumor-only?)
+               (conj ["normal" normal-r1 normal-r2]))]
+           ~@(gen-controlpanel-config control-panel)
+           [:mutation-call
+            [["tumor" ~(if tumor-only? "None" "normal") "None"]]]
+           [:sv-detection
+            [~(conj ["tumor"]
+                    (if tumor-only? "None" "normal")
+                    (if (seq control-panel) "control_panel" "None"))]]
+           ~@(when include-qc?
+               `[[:qc
+                  [["tumor"] ~@(when-not tumor-only? [["normal"]])]]])]
+         (gen-input-file)))))
 
-(defn gen-rna-input [{:keys [r1 r2 control-panel]}]
-  (-> `[[:fastq [["rna" ~r1 ~r2]]]
-        ~@(gen-controlpanel-config control-panel)
-        [:sv-detection
-         [["rna" "None" ~(if (seq control-panel) "control_panel" "None")]]]
-        [:fusion
-         [["rna" ~(if (seq control-panel) "control_panel" "None")]]]
-        [:expression [["rna"]]]
-        [:intron-retention [["rna"]]]
-        [:qc [["rna"]]]]
-      (gen-input-file)))
+(defn gen-rna-input
+  ([samples] (gen-rna-input samples {}))
+  ([{:keys [r1 r2 control-panel]} {:keys [include-qc?]}]
+   (-> `[[:fastq [["rna" ~r1 ~r2]]]
+         ~@(gen-controlpanel-config control-panel)
+         [:sv-detection
+          [["rna" "None" ~(if (seq control-panel) "control_panel" "None")]]]
+         [:fusion
+          [["rna" ~(if (seq control-panel) "control_panel" "None")]]]
+         [:expression [["rna"]]]
+         [:intron-retention [["rna"]]]
+         ~@(when include-qc?
+             [[:qc [["rna"]]]])]
+       (gen-input-file))))

--- a/test/src/genomon_api/util/csv_test.clj
+++ b/test/src/genomon_api/util/csv_test.clj
@@ -1,11 +1,22 @@
 (ns genomon-api.util.csv-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest are]]
+  (:require [clojure.test :refer [deftest are]]
             [genomon-api.util.csv :as csv]))
 
 (deftest gen-dna-input-test
-  (are [samples expected] (= expected (csv/gen-dna-input samples))
+  (are [samples opts expected] (= expected (csv/gen-dna-input samples opts))
     {:tumor {:r1 "tr1.fastq" :r2 "tr2.fastq"}}
+    {}
+    "[fastq]
+tumor,tr1.fastq,tr2.fastq
+
+[mutation_call]
+tumor,None,None
+
+[sv_detection]
+tumor,None,None"
+
+    {:tumor {:r1 "tr1.fastq" :r2 "tr2.fastq"}}
+    {:include-qc? true}
     "[fastq]
 tumor,tr1.fastq,tr2.fastq
 
@@ -20,6 +31,20 @@ tumor"
 
     {:tumor {:r1 "tr1.fastq" :r2 "tr2.fastq"}
      :normal {:r1 "nr1.fastq" :r2 "nr2.fastq"}}
+    {}
+    "[fastq]
+tumor,tr1.fastq,tr2.fastq
+normal,nr1.fastq,nr2.fastq
+
+[mutation_call]
+tumor,normal,None
+
+[sv_detection]
+tumor,normal,None"
+
+    {:tumor {:r1 "tr1.fastq" :r2 "tr2.fastq"}
+     :normal {:r1 "nr1.fastq" :r2 "nr2.fastq"}}
+    {:include-qc? true}
     "[fastq]
 tumor,tr1.fastq,tr2.fastq
 normal,nr1.fastq,nr2.fastq
@@ -36,6 +61,7 @@ normal"
 
     {:tumor {:r1 "tr1.fastq" :r2 "tr2.fastq"}
      :control-panel ["sample1.bam" "sample2.bam"]}
+    {}
     "[fastq]
 tumor,tr1.fastq,tr2.fastq
 
@@ -50,14 +76,12 @@ control_panel,control_sample0,control_sample1
 tumor,None,None
 
 [sv_detection]
-tumor,None,control_panel
-
-[qc]
-tumor"
+tumor,None,control_panel"
 
     {:tumor {:r1 "tr1.fastq" :r2 "tr2.fastq"}
      :normal {:r1 "nr1.fastq" :r2 "nr2.fastq"}
      :control-panel ["sample1.bam" "sample2.bam"]}
+    {}
     "[fastq]
 tumor,tr1.fastq,tr2.fastq
 normal,nr1.fastq,nr2.fastq
@@ -73,17 +97,31 @@ control_panel,control_sample0,control_sample1
 tumor,normal,None
 
 [sv_detection]
-tumor,normal,control_panel
-
-[qc]
-tumor
-normal"
+tumor,normal,control_panel"
 
     ))
 
 (deftest gen-rna-input-test
-  (are [samples expected] (= expected (csv/gen-rna-input samples))
+  (are [samples opts expected] (= expected (csv/gen-rna-input samples opts))
     {:r1 "r1.fastq" :r2 "r2.fastq"}
+    {}
+    "[fastq]
+rna,r1.fastq,r2.fastq
+
+[sv_detection]
+rna,None,None
+
+[fusion]
+rna,None
+
+[expression]
+rna
+
+[intron_retention]
+rna"
+
+    {:r1 "r1.fastq" :r2 "r2.fastq"}
+    {:include-qc? true}
     "[fastq]
 rna,r1.fastq,r2.fastq
 
@@ -103,6 +141,30 @@ rna
 rna"
 
     {:r1 "r1.fastq" :r2 "r2.fastq" :control-panel ["sample1.bam"]}
+    {}
+    "[fastq]
+rna,r1.fastq,r2.fastq
+
+[bam_tofastq]
+control_sample0,sample1.bam
+
+[controlpanel]
+control_panel,control_sample0
+
+[sv_detection]
+rna,None,control_panel
+
+[fusion]
+rna,control_panel
+
+[expression]
+rna
+
+[intron_retention]
+rna"
+
+    {:r1 "r1.fastq" :r2 "r2.fastq" :control-panel ["sample1.bam"]}
+    {:include-qc? true}
     "[fastq]
 rna,r1.fastq,r2.fastq
 


### PR DESCRIPTION
This PR allows the QC tasks to be disabled and changes them to be disabled by default.

To this end, a new option `:include-qc?` will be added to the `genomon.util.csv/gen-{dna,rna}-input` functions to emit the settings for the QC task to Genomon's [sample file](https://genomon.readthedocs.io/ja/latest/dna_sample_csv.html) only when `:include-qc? true` is specified.