### PR TITLE
Release 0.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Xcoo, Inc. <developer@xcoo.jp>"
 LABEL GIT_COMMIT=${GIT_COMMIT}
 ENV GIT_COMMIT=${GIT_COMMIT}
 COPY --from=builder \
-  /root/genomon-api/target/genomon-api-0.1.4-SNAPSHOT-standalone.jar \
+  /root/genomon-api/target/genomon-api-0.1.4-standalone.jar \
   /usr/share/genomon-api/genomon-api.jar
 COPY docker/genomon-api /usr/local/bin/genomon-api
 COPY resources/genomon_api/ /etc/genomon-api/genomon_api/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Xcoo, Inc. <developer@xcoo.jp>"
 LABEL GIT_COMMIT=${GIT_COMMIT}
 ENV GIT_COMMIT=${GIT_COMMIT}
 COPY --from=builder \
-  /root/genomon-api/target/genomon-api-0.1.4-standalone.jar \
+  /root/genomon-api/target/genomon-api-0.1.5-SNAPSHOT-standalone.jar \
   /usr/share/genomon-api/genomon-api.jar
 COPY docker/genomon-api /usr/local/bin/genomon-api
 COPY resources/genomon_api/ /etc/genomon-api/genomon_api/

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [instaparse "1.4.12"]
                  [org.flatland/ordered "1.15.10"]
                  [io.dropwizard.metrics/metrics-core "4.2.15"]
-                 [io.dropwizard.metrics/metrics-healthchecks "4.2.7"]]
+                 [io.dropwizard.metrics/metrics-healthchecks "4.2.15"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]
   :main ^:skip-aot genomon-api.main

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                                commons-codec]]
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
-                 [com.cognitect.aws/api "0.8.539"]
+                 [com.cognitect.aws/api "0.8.641"]
                  [com.cognitect.aws/endpoints "1.1.12.136"]
                  [com.cognitect.aws/s3 "814.2.1053.0"]
                  [camel-snake-kebab "0.4.3"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.gnu.org/licenses/gpl-3.0.html"}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.clojure/core.async "1.5.648"]
+                 [org.clojure/core.async "1.6.673"]
                  [integrant "0.8.0"]
                  [duct/core "0.8.0"
                   :exclusions [medley]]

--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,6 @@
                  [com.cognitect.aws/api "0.8.539"]
                  [com.cognitect.aws/endpoints "1.1.12.136"]
                  [com.cognitect.aws/s3 "814.2.1053.0"]
-                 [clj-commons/clj-yaml "0.7.107"]
                  [camel-snake-kebab "0.4.3"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.15.10"]

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
                  [camel-snake-kebab "0.4.3"]
                  [instaparse "1.4.12"]
                  [org.flatland/ordered "1.15.10"]
-                 [io.dropwizard.metrics/metrics-core "4.2.7"]
+                 [io.dropwizard.metrics/metrics-core "4.2.15"]
                  [io.dropwizard.metrics/metrics-healthchecks "4.2.7"]]
   :plugins [[duct/lein-duct "0.12.1"]
             [lein-eftest "0.5.9"]]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [javax.activation/activation "1.1.1"]
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.641"]
-                 [com.cognitect.aws/endpoints "1.1.12.136"]
+                 [com.cognitect.aws/endpoints "1.1.12.398"]
                  [com.cognitect.aws/s3 "814.2.1053.0"]
                  [camel-snake-kebab "0.4.3"]
                  [instaparse "1.4.12"]

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.flatland/ordered "1.15.10"]
                  [io.dropwizard.metrics/metrics-core "4.2.15"]
                  [io.dropwizard.metrics/metrics-healthchecks "4.2.15"]]
-  :plugins [[duct/lein-duct "0.12.1"]
+  :plugins [[duct/lein-duct "0.12.3"]
             [lein-eftest "0.5.9"]]
   :main ^:skip-aot genomon-api.main
   :resource-paths ["resources" "target/resources"]

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [org.apache.commons/commons-compress "1.22"]
                  [mysql/mysql-connector-java "8.0.32"]
                  [com.layerware/hugsql "0.5.3"]
-                 [metosin/reitit "0.5.15"]
+                 [metosin/reitit "0.5.18"]
                  [metosin/ring-http-response "0.9.3"
                   :exclusions [ring/ring-core]]
                  [com.github.docker-java/docker-java "3.2.14"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject genomon-api "0.1.4-SNAPSHOT"
+(defproject genomon-api "0.1.4"
   :description "An API server of genomon_pipeline_cloud"
   :url "https://github.com/chrovis/genomon-api"
   :license {:name "GNU General Pulibc License, Version 3.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject genomon-api "0.1.4"
+(defproject genomon-api "0.1.5-SNAPSHOT"
   :description "An API server of genomon_pipeline_cloud"
   :url "https://github.com/chrovis/genomon-api"
   :license {:name "GNU General Pulibc License, Version 3.0"

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]
                  [org.apache.commons/commons-compress "1.21"]
                  [mysql/mysql-connector-java "8.0.28"]
-                 [com.layerware/hugsql "0.5.1"]
+                 [com.layerware/hugsql "0.5.3"]
                  [metosin/reitit "0.5.15"]
                  [metosin/ring-http-response "0.9.3"
                   :exclusions [ring/ring-core]]

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
                  [com.cognitect.aws/endpoints "1.1.12.136"]
                  [com.cognitect.aws/s3 "814.2.1053.0"]
                  [clj-commons/clj-yaml "0.7.107"]
-                 [camel-snake-kebab "0.4.2"]
+                 [camel-snake-kebab "0.4.3"]
                  [instaparse "1.4.10"]
                  [org.flatland/ordered "1.15.10"]
                  [io.dropwizard.metrics/metrics-core "4.2.7"]

--- a/project.clj
+++ b/project.clj
@@ -66,6 +66,6 @@
                                    [kerodon "0.9.1"
                                     :exclusions [clj-time
                                                  ring/ring-codec]]
-                                   [com.h2database/h2 "2.1.210"]
+                                   [com.h2database/h2 "2.1.214"]
                                    [com.gearswithingears/shrubbery "0.4.1"]]
                   :global-vars {*warn-on-reflection* true}}})

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [metosin/reitit "0.5.15"]
                  [metosin/ring-http-response "0.9.3"
                   :exclusions [ring/ring-core]]
-                 [com.github.docker-java/docker-java "3.2.12"
+                 [com.github.docker-java/docker-java "3.2.14"
                   :exclusions [commons-io
                                commons-codec]]
                  [javax.activation/activation "1.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                  [io.dropwizard.metrics/metrics-core "4.2.15"]
                  [io.dropwizard.metrics/metrics-healthchecks "4.2.15"]]
   :plugins [[duct/lein-duct "0.12.3"]
-            [lein-eftest "0.5.9"]]
+            [lein-eftest "0.6.0"]]
   :main ^:skip-aot genomon-api.main
   :resource-paths ["resources" "target/resources"]
   :test-paths     ["test/src"]

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                commons-codec
                                com.fasterxml.jackson.datatype/jackson-datatype-jsr310]]
                  [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]
-                 [org.apache.commons/commons-compress "1.21"]
+                 [org.apache.commons/commons-compress "1.22"]
                  [mysql/mysql-connector-java "8.0.32"]
                  [com.layerware/hugsql "0.5.3"]
                  [metosin/reitit "0.5.15"]

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                                com.fasterxml.jackson.datatype/jackson-datatype-jsr310]]
                  [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]
                  [org.apache.commons/commons-compress "1.21"]
-                 [mysql/mysql-connector-java "8.0.28"]
+                 [mysql/mysql-connector-java "8.0.32"]
                  [com.layerware/hugsql "0.5.3"]
                  [metosin/reitit "0.5.15"]
                  [metosin/ring-http-response "0.9.3"

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "GNU General Pulibc License, Version 3.0"
             :url "https://www.gnu.org/licenses/gpl-3.0.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.10.3"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/core.async "1.5.648"]
                  [integrant "0.8.0"]
                  [duct/core "0.8.0"

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
                  [com.cognitect.aws/endpoints "1.1.12.136"]
                  [com.cognitect.aws/s3 "814.2.1053.0"]
                  [camel-snake-kebab "0.4.3"]
-                 [instaparse "1.4.10"]
+                 [instaparse "1.4.12"]
                  [org.flatland/ordered "1.15.10"]
                  [io.dropwizard.metrics/metrics-core "4.2.7"]
                  [io.dropwizard.metrics/metrics-healthchecks "4.2.7"]]

--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,7 @@
                   :resource-paths ["dev/resources" "test/resources"]
                   :dependencies   [[integrant/repl "0.3.2"]
                                    [hawk "0.2.11"]
-                                   [eftest "0.5.9"
+                                   [eftest "0.6.0"
                                     :exclusions [mvxcvi/puget]]
                                    [kerodon "0.9.1"
                                     :exclusions [clj-time

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  [com.cognitect/anomalies "0.1.12"]
                  [com.cognitect.aws/api "0.8.641"]
                  [com.cognitect.aws/endpoints "1.1.12.398"]
-                 [com.cognitect.aws/s3 "814.2.1053.0"]
+                 [com.cognitect.aws/s3 "825.2.1250.0"]
                  [camel-snake-kebab "0.4.3"]
                  [instaparse "1.4.12"]
                  [org.flatland/ordered "1.15.10"]

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                                crypto-random
                                commons-codec
                                com.fasterxml.jackson.datatype/jackson-datatype-jsr310]]
-                 [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]
+                 [org.eclipse.jetty/jetty-server "9.4.48.v20220622"]
                  [org.apache.commons/commons-compress "1.22"]
                  [mysql/mysql-connector-java "8.0.32"]
                  [com.layerware/hugsql "0.5.3"]

--- a/src/genomon_api/aws.clj
+++ b/src/genomon_api/aws.clj
@@ -2,13 +2,14 @@
   (:require [integrant.core :as ig]
             [cognitect.anomalies :as anomalies]
             [cognitect.aws.client.api :as aws]
+            cognitect.aws.client.impl
             [cognitect.aws.credentials :as credentials]
             [ring.util.http-response :as hr]
             [camel-snake-kebab.core :as csk]
             [camel-snake-kebab.extras :as csk-ex]
             [genomon-api.storage :as storage])
   (:import [java.util Date]
-           [cognitect.aws.client Client]))
+           [cognitect.aws.client.impl Client]))
 
 (defn- ->edn [response]
   (-> (csk-ex/transform-keys csk/->kebab-case-keyword response)


### PR DESCRIPTION
Releases 0.1.4.

The outdated dependencies will also be updated. Some notes:

- Dropped clj-yaml, which is not used now
- Pinned jetty-server to 9.4.48.v20220622, the compatible version to jetty-client used in aws-api
- Updated `cognitect.aws.client.Client`’s fully-qualified name, which was moved into the `cognitect.aws.client.impl` namespace in aws-api 0.8.589